### PR TITLE
Add columns to DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor/*/*/.gitignore
 vendor/*/*/.travis.yml
 vendor/*/*/phpunit.xml.dist
 
+*.bak

--- a/CRM/Geocoder/DAO/Geocoder.php
+++ b/CRM/Geocoder/DAO/Geocoder.php
@@ -77,6 +77,20 @@ class CRM_Geocoder_DAO_Geocoder extends CRM_Core_DAO {
    */
   public $api_key;
 
+/**
+   * Use licensed provider ?
+   *
+   * @var string
+   */
+  public $is_licensed;
+
+/**
+   * Provider Paramaters
+   *
+   * @var string
+   */
+  public $parameters;
+
   /**
    * URL (if required)
    *
@@ -221,7 +235,30 @@ class CRM_Geocoder_DAO_Geocoder extends CRM_Core_DAO {
           'description' => 'API Key',
           'maxlength' => 255,
           'size' => CRM_Utils_Type::HUGE,
+          'table_name' => 'civicrm_geocoder',
+          'entity' => 'Geocoder',
+          'bao' => 'CRM_Geocoder_DAO_Geocoder',
+          'localizable' => 0,
+        ],
 
+        'is_licensed' => [
+          'name' => 'is_licensed',
+          'title' => ts('Licensed ?'),
+          'type' => CRM_Utils_Type::T_BOOLEAN,
+          'description' => 'Use licensed provider ?',
+          'table_name' => 'civicrm_geocoder',
+          'entity' => 'Geocoder',
+          'bao' => 'CRM_Geocoder_DAO_Geocoder',
+          'localizable' => 0,
+        ],
+
+        'parameters' => [
+          'name' => 'parameters',
+          'type' => CRM_Utils_Type::T_STRING,
+          'title' => ts('Provider parameters'),
+          'description' => 'parameters to pass to provider',
+          'maxlength' => 255,
+          'size' => CRM_Utils_Type::HUGE,
           'table_name' => 'civicrm_geocoder',
           'entity' => 'Geocoder',
           'bao' => 'CRM_Geocoder_DAO_Geocoder',

--- a/CRM/Geocoder/Upgrader.php
+++ b/CRM/Geocoder/Upgrader.php
@@ -45,6 +45,13 @@ class CRM_Geocoder_Upgrader extends CRM_Geocoder_Upgrader_Base {
     }
   }
 
+
+  public function upgrade_1100() {
+    $this->ctx->log->info('Applying update 1100');
+    $this->executeSqlFile('sql/upgrade_1100.sql');
+    return TRUE;
+  }
+
   /**
    * Example: Run an external SQL script when the module is uninstalled.
    */

--- a/CRM/Utils/Geocode/Geocoder.php
+++ b/CRM/Utils/Geocode/Geocoder.php
@@ -109,7 +109,13 @@ class CRM_Utils_Geocode_Geocoder {
         }
         $argument = self::getProviderArgument($geocoder);
 
+        // Check to see if this provider is licensed 
+        if ((isset($geocoder['is_licensed'])) && ($geocoder['is_licensed'] > 0)) {
+           $provider = new $classString(self::$client, $argument, TRUE);
+        }
+        else {
         $provider = new $classString(self::$client, $argument);
+        }
 
         $geocoderObj = new \Geocoder\StatefulGeocoder($provider, $locale);
         $result = $geocoderObj->geocodeQuery(GeocodeQuery::create($geocodableAddress));

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/eileenmcnaughton/org.wikimedia.geocoder</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2018-01-17</releaseDate>
-  <version>1.0</version>
+  <releaseDate>2019-06-01</releaseDate>
+  <version>1.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.0</ver>

--- a/sql/install.sql
+++ b/sql/install.sql
@@ -6,6 +6,8 @@ CREATE TABLE `civicrm_geocoder` (
   `is_active` tinyint(1) DEFAULT '0' COMMENT 'Enabled?',
   `weight` int(10) unsigned DEFAULT NULL COMMENT 'Weight',
   `api_key` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL COMMENT 'API Key',
+  `is_licensed` tinyint(1) DEFAULT '0' COMMENT 'Use licensed provider ?',
+  `parameters` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL COMMENT 'parameters to pass to provider',
   `url` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL COMMENT 'URL (if required)',
   `required_fields` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL COMMENT 'json array of fields required for this to parse',
   `retained_response_fields` varchar(255) COLLATE utf8_unicode_ci DEFAULT '["geo_code_1","geo_code_2"]' COMMENT 'fields to be retained from the response',

--- a/sql/upgrade_1100.sql
+++ b/sql/upgrade_1100.sql
@@ -1,0 +1,2 @@
+ALTER TABLE civicrm_geocoder ADD COLUMN IF NOT EXISTS is_licensed TINYINT(1) DEFAULT '0' COMMENT 'Use licensed provider ?';
+ALTER TABLE civicrm_geocoder ADD COLUMN IF NOT EXISTS parameters VARCHAR(255) COLLATE utf8_unicode_ci DEFAULT NULL COMMENT 'parameters to pass to provider';

--- a/xml/schema/CRM/Geocoder/Geocoder.xml
+++ b/xml/schema/CRM/Geocoder/Geocoder.xml
@@ -56,6 +56,18 @@
         <length>255</length>
         <comment>API Key</comment>
     </field>
+        <field>
+        <name>is_licensed</name>
+        <type>boolean</type>
+        <comment>Use licensed provider ?</comment>
+        <default>0</default>
+    </field>
+    <field>
+        <name>parameters</name>
+        <type>varchar</type>
+        <length>255</length>
+        <comment>parameters to pass to provider</comment>
+    </field>
     <field>
         <name>url</name>
         <type>varchar</type>


### PR DESCRIPTION
Add two columns :
is_licensed ==> if != 0, use provider licensed version
paramaters ==> to define specifics parameters for each provider (not yet used)

I rather used one more column in the database, because it allows for example, to define 2 mapQuest providers. The first using the Open version, the second, used if the first one does not find a result, using the licensed version.
This avoids unnecessarily reaching the free threshold.