### PR TITLE
Build the search string with state name instead of id

### DIFF
--- a/CRM/Utils/Geocode/Geocoder.php
+++ b/CRM/Utils/Geocode/Geocoder.php
@@ -338,8 +338,28 @@ class CRM_Utils_Geocode_Geocoder {
     // filter out unrelated keys
 
     $addressValues = array_intersect_key($addressValues, array_fill_keys($addressFields, 1));
+    // Convert the state id to name
+    if ($addressValues['state_province_id']) {
+      $addressValues['state_province_id'] = self::getStateName($addressValues['state_province_id']);
+    }
     $geocodableAddress = implode(',', array_filter($addressValues));
     return $geocodableAddress;
+  }
+
+  /**
+   * Convert the state id to name
+   * @param int|string $state the id
+   *
+   * @return string the state name
+   */
+  protected static function getStateName($state) {
+    if (!is_numeric($state)) {
+      return $state;
+    }
+    $result = civicrm_api3('StateProvince', 'getsingle', [
+      'id' => $state,
+    ]);
+    return $result['name'];
   }
 
   /**


### PR DESCRIPTION
Overall
------
The query string is built with the state id. Then Open Street Map failed to parse it when it comes with a street number. 

Before
------
The state in the query string is id.

After
------
The state in the query string is state name.

Comment
------
Fun thing is that OSM can parse it when there is no street number.
Agileware ref: CIVICRM-1317