### PR TITLE
Add UK (well, GB) postcode geocoder

### DIFF
--- a/CRM/Utils/Geocode/Geocoder.php
+++ b/CRM/Utils/Geocode/Geocoder.php
@@ -242,6 +242,7 @@ class CRM_Utils_Geocode_Geocoder {
         );
       }
     }
+    // xxx this ALWAYS exits here since $values is not defined.
     if (empty($values['id'])) {
       return;
     }
@@ -382,6 +383,9 @@ class CRM_Utils_Geocode_Geocoder {
 
       case 'city':
         return $firstResult->getLocality();
+
+      case 'postal_code':
+        return $firstResult->getPostalCode();
 
       case 'state_province_id':
         if (empty($values['country_id'])) {
@@ -552,25 +556,7 @@ class CRM_Utils_Geocode_Geocoder {
         $parameters[] = $keyFields[$parts[1]];
       }
     }
-    switch (count($parameters)) {
-      case 0:
-        return new $classString(self::$client);
-
-      case 1:
-        return new $classString(self::$client, $parameters[0]);
-
-      case 2:
-        return new $classString(self::$client, $parameters[0], $parameters[1]);
-
-      case 3:
-        return new $classString(self::$client, $parameters[0], $parameters[1], $parameters[2]);
-
-      case 4:
-        return new $classString(self::$client, $parameters[0], $parameters[1], $parameters[2], $parameters[3]);
-
-      case 5:
-        return new $classString(self::$client, $parameters[0], $parameters[1], $parameters[2], $parameters[3], $parameters[4]);
-    }
+    return new $classString(self::$client, ...$parameters);
   }
 
 }

--- a/Provider/UKPostcodeProvider.php
+++ b/Provider/UKPostcodeProvider.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file works with the Geocoder package.
+ *
+ * @author Rich Lott / Artful Robot <forums@artfulrobot.uk>
+ */
+
+namespace Geocoder\Provider;
+
+use Civi;
+use Geocoder\Collection;
+use Geocoder\Exception\UnsupportedOperation;
+use Geocoder\Model\AddressBuilder;
+use Geocoder\Model\AddressCollection;
+use Geocoder\Query\GeocodeQuery;
+use Geocoder\Query\ReverseQuery;
+use Geocoder\Provider\AbstractProvider;
+use Geocoder\Provider\Provider;
+use Geocoder\Exception\CollectionIsEmpty;
+
+final class UKPostcodeProvider extends AbstractProvider implements Provider
+{
+  /**
+   * @param HttpClient $dummy (unused)
+   *
+   * @throws \Exception
+   */
+    public function __construct($dummy) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function geocodeQuery(GeocodeQuery $query): Collection {
+
+      if (!isset(Civi::$statics[__CLASS__])) {
+        Civi::$statics[__CLASS__] = (bool) (\CRM_Core_DAO::singleValueQuery("SHOW TABLES LIKE 'civicrm_open_postcode_geo_uk'"));
+      }
+      if (!Civi::$statics[__CLASS__]) {
+        // We don't have the data table available.
+        throw new CollectionIsEmpty();
+      }
+
+      $postcodeNoSpace = preg_replace('/ +/', '', $query->getText());
+
+      $sql = "
+         SELECT *
+         FROM civicrm_open_postcode_geo_uk
+         WHERE postcode_no_space = %1";
+
+      $result = \CRM_Core_DAO::executeQuery(
+        $sql,
+        [1 => [$postcodeNoSpace, 'String']]
+      );
+
+      $builder = new AddressBuilder($this->getName());
+      if ($result->fetch()) {
+        $builder->setCoordinates($result->latitude, $result->longitude);
+        $builder->setPostalCode($result->postcode);
+        return new AddressCollection([$builder->build()]);
+      }
+
+      throw new CollectionIsEmpty();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reverseQuery(ReverseQuery $query): Collection
+    {
+        throw new UnsupportedOperation('The data table provider is not able to do reverse geocoding yet.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string {
+      return 'uk_postcode';
+    }
+}

--- a/ProviderMetadata/2_UKPostcode.mgd.geo.php
+++ b/ProviderMetadata/2_UKPostcode.mgd.geo.php
@@ -1,0 +1,21 @@
+<?php
+return [
+  [
+    'name' => 'uk_postcode',
+    'entity' => 'Geocoder',
+    'params' => [
+      'version' => 3,
+      'name' => 'uk_postcode',
+      'title' => 'UK postcode based geocoding',
+      'class' => 'UKPostcodeProvider',
+      'valid_countries' => ['GB'],
+      'required_fields' => ['postal_code'],
+      'retained_response_fields' => '["geo_code_1","geo_code_2", "postal_code"]',
+      'datafill_response_fields' => [],
+    ],
+    'metadata' => [
+      'is_enabled_on_install' => FALSE,
+    ]
+  ]
+];
+

--- a/README.md
+++ b/README.md
@@ -5,15 +5,17 @@ Requires - CiviCRM 5.28, php 7.1
 Implementation of geocoder library (which itself supports multiple providers) https://github.com/geocoder-php/mapquest-provider. Only those that have been tested are enabled so far.
 
 When an address is edited CiviCRM will obtain additional data from the geocoding provider
-and save it to the civicrm_address database with the address. It will also geocode addresses
+and save it to the `civicrm_address` database with the address. It will also geocode addresses
 to be used as the focal point of proximity searches or for event maps.
 
 Note that the terms of data use by geocoding providers varies and it is your responsibility
 to understand and adhere to them.
 
 Currently enabled geocoders are
+
 - Open Street Maps - this is zero-config & is enabled as the default (lowest weight)on install if you have no existing mapping provider
 - USZipGeocoder - this is enabled on install & has no config. It will work as a fallback for US addresses only.
+- UK Postcodes - see below
 - MapQuest - requires an API key to be used
 - GoogleMaps - requires an API key to be used - this is enabled on install as the default if you
 already have google configured as your provider. However the Terms of service suggest it may not be a good choose https://support.google.com/code/answer/55180?hl=en
@@ -22,6 +24,7 @@ already have google configured as your provider. However the Terms of service su
 - Addok (not enabled by default)
 
 Features
+
 - Threshold standdown period. If the geocoding quota is hit for a provider it is not used
 again until the standdown has expired. By default the standdown is 1 minute but it is configurable per geocoder instance.
 - Provider fall over. If a provider is not valid (e.g because the quota was hit or it only does a
@@ -75,8 +78,10 @@ or multipart user data - ie
 api_key = {'app_id' : 'xy', 'app_code' : 'z'}
 
 Next steps
+
 1) make geocoders configurable - the form at /civicrm/a/#/geocoders
 currently only gives view access. I'm committed to extending the form based on the metadata rather than hard-coding & have added 'help_text' & 'user_editable_fields' to the entity specs. The plan is to expose these via getfields & then use them to drive the form. I'd like a cool way to manage weight.
+
 2) consider caching - for https providers - https://github.com/geocoder-php/Geocoder/blob/master/docs/cookbook/cache.md
 For DB providers we could cache the result of each query. The downside is potential
 large memory usage for little query gain if there is a big spread of postal codes.
@@ -84,3 +89,56 @@ large memory usage for little query gain if there is a big spread of postal code
 
 Also of interest
 - library supports ip address geocoding
+
+## UK Postcode geocoder
+
+- This *only* goes on postcodes which it looks up from a database (so no online service, no fees, limits or latency).
+
+- It can handle *and correct* postcodes with spaces missing/in wrong places.
+
+- It is not installed by default because of the size of the data.
+
+### Data License
+
+Due to licensing, only GB's postcodes are included, not the UK's. (i.e. no
+Northern Ireland postcodes are included.) You may be permitted to add NI
+postcodes to your local database, if you can get them, but they can't be
+distributed as part of this extension.
+
+The data came from https://www.getthedata.com/open-postcode-geo
+
+> Open Postcode Geo is derived from the ONS Postcode Directory.
+>
+> From the ONS:
+>
+> http://www.ons.gov.uk/methodology/geography/licences
+>
+> Our postcode products (derived from Code-Point(R) Open) are subject to the Open Government Licence and the Ordnance Survey OpenData Licence.
+>
+> - Contains OS data (c) Crown copyright and database right 2021
+> - Contains Royal Mail data (c) Royal Mail copyright and database right 2021
+> - Contains National Statistics data (c) Crown copyright and database right 2021
+
+### Downloading the data yourself
+
+1. grab the .sql.gz file from https://www.getthedata.com/open-postcode-geo and unzip it.
+2. Edit the table name to `civicrm_open_postcode_geo_uk` (you can do this with `sed -i 's/open_postcode_geo/civicrm_open_postcode_geo_uk/g' /path/to/open_postcode_geo.sql`)
+3. Import the data into your CiviCRM database
+4. Run SQL like this:
+    ```sql
+    ALTER TABLE civicrm_open_postcode_geo_uk
+    DROP `status`,
+    DROP usertype,
+    DROP easting,
+    DROP northing,
+    DROP positional_quality_indicator,
+    DROP country,
+    DROP postcode_fixed_width_seven,
+    DROP postcode_fixed_width_eight,
+    DROP postcode_area,
+    DROP postcode_district,
+    DROP postcode_sector,
+    DROP outcode,
+    DROP incode;
+    ```
+5. Enable the UK Postcode geocoder. Not sure if there's a UI for this, but you can do it via the API (v3).

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The data came from https://www.getthedata.com/open-postcode-geo
 > - Contains Royal Mail data (c) Royal Mail copyright and database right 2021
 > - Contains National Statistics data (c) Crown copyright and database right 2021
 
-### Downloading the data yourself
+### Downloading the data
 
 1. grab the .sql.gz file from https://www.getthedata.com/open-postcode-geo and unzip it.
 2. Edit the table name to `civicrm_open_postcode_geo_uk` (you can do this with `sed -i 's/open_postcode_geo/civicrm_open_postcode_geo_uk/g' /path/to/open_postcode_geo.sql`)
@@ -139,6 +139,8 @@ The data came from https://www.getthedata.com/open-postcode-geo
     DROP postcode_district,
     DROP postcode_sector,
     DROP outcode,
-    DROP incode;
+    DROP incode,
+    DROP KEY IF EXISTS postcode_no_space,
+    ADD PRIMARY KEY (postcode_no_space);
     ```
 5. Enable the UK Postcode geocoder. Not sure if there's a UI for this, but you can do it via the API (v3).

--- a/info.xml
+++ b/info.xml
@@ -27,4 +27,7 @@
   <civix>
     <namespace>CRM/Geocoder</namespace>
   </civix>
+  <classloader>
+    <psr4 prefix="Geocoder\Provider\" path="Provider"/>
+  </classloader>
 </extension>

--- a/sql/open_postcode_geo-test.sql
+++ b/sql/open_postcode_geo-test.sql
@@ -7,6 +7,6 @@ CREATE TABLE `civicrm_open_postcode_geo_uk` (
   `longitude` decimal(9,6) DEFAULT NULL,
   `postcode_no_space` char(7) NOT NULL,
   UNIQUE KEY `postcode_no_space` (`postcode_no_space`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB;
 INSERT INTO `civicrm_open_postcode_geo_uk` VALUES ('SW1A 0AA',51.499840,-0.124663,'SW1A0AA');
 

--- a/sql/open_postcode_geo-test.sql
+++ b/sql/open_postcode_geo-test.sql
@@ -1,0 +1,12 @@
+-- Test data, one row.
+-- See README for getting the full data.
+DROP TABLE IF EXISTS `civicrm_open_postcode_geo_uk`;
+CREATE TABLE `civicrm_open_postcode_geo_uk` (
+  `postcode` char(8) NOT NULL PRIMARY KEY,
+  `latitude` decimal(9,6) DEFAULT NULL,
+  `longitude` decimal(9,6) DEFAULT NULL,
+  `postcode_no_space` char(7) NOT NULL,
+  UNIQUE KEY `postcode_no_space` (`postcode_no_space`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+INSERT INTO `civicrm_open_postcode_geo_uk` VALUES ('SW1A 0AA',51.499840,-0.124663,'SW1A0AA');
+

--- a/tests/phpunit/GeocoderTest.php
+++ b/tests/phpunit/GeocoderTest.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/BaseTestClass.php';
 
 use Civi\Test\CiviEnvBuilder;
+use Civi\Api4\Address;
 use CRM_Geocoder_ExtensionUtil as E;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\HookInterface;
@@ -45,6 +46,9 @@ class GeocoderTest extends BaseTestClass {
       ->installMe(__DIR__)
       ->sqlFile(__DIR__  . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..'
         . DIRECTORY_SEPARATOR . 'sql' . DIRECTORY_SEPARATOR . 'nz_sample_geoname_table.sql')
+      // Add the UK data (1 test row)
+      ->sqlFile(__DIR__  . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..'
+        . DIRECTORY_SEPARATOR . 'sql' . DIRECTORY_SEPARATOR . 'open_postcode_geo-test.sql')
       ->apply();
   }
 
@@ -156,7 +160,8 @@ class GeocoderTest extends BaseTestClass {
   }
 
   /**
-   * Test that postal codes are prepended with zeros for minimum length.
+   * Test that postal codes are suitably formatted for the locale
+   * (ex. left-pad with 0s)
    *
    * This only applies to NZ & US at the moment but as we get validation for
    * more countries we can extend.
@@ -205,6 +210,61 @@ class GeocoderTest extends BaseTestClass {
     }
   }
 
+  public function testUK() {
+
+    // We need to enable the uk_postcode geocoder
+    $id = (int) civicrm_api3('Geocoder', 'getvalue', ['name' => 'uk_postcode', 'return' => 'id']);
+    if (!$id) {
+      throw new \Exception("Failed to find uk_postcode geocoder");
+    }
+    civicrm_api3('Geocoder', 'create', ['is_active' => 1, 'id' => $id]);
+
+    $this->configureGeoCoders([
+      'uk_postcode' => [
+        'name' => 'uk_postcode',
+        'is_active' => 1,
+        'weight' => 1,
+      ],
+    ]);
+
+    // Check that passing in a valid, known postcode yields the correct latitude.
+    $address = $this->callAPISuccess('Address', 'create', [
+      'postal_code'      => 'SW1A 0AA',
+      'location_type_id' => 'Home',
+      'contact_id'       => $this->ids['contact'][0],
+      'country_id'       => 'GB',
+    ]);
+    $address = $this->callAPISuccessGetSingle('Address', ['id' => $address['id']]);
+    $this->assertEquals('51.499840', $address['geo_code_1'] ?? NULL);
+    $this->assertEquals('SW1A 0AA', $address['postal_code'] ?? NULL);
+    Address::delete(FALSE)->addWhere('id', '=', $address['id']);
+
+    // Check that passing in a malformed but correct postcode without spaces
+    // (a) gets latitude and (b) gets corrected.
+    $address = $this->callAPISuccess('Address', 'create', [
+      'postal_code' => 'SW1A0AA',
+      'location_type_id' => 'Home',
+      'contact_id' => $this->ids['contact'][0],
+      'country_id' => 'GB',
+    ]);
+    $address = $this->callAPISuccessGetSingle('Address', ['id' => $address['id']]);
+    $this->assertEquals('51.499840', $address['geo_code_1'] ?? NULL);
+    $this->assertEquals('SW1A 0AA', $address['postal_code'] ?? NULL);
+    Address::delete(FALSE)->addWhere('id', '=', $address['id']);
+
+    // Check that passing in bad postcode/one we don't know does no damage.
+    $address = $this->callAPISuccess('Address', 'create', [
+      'postal_code' => 'ZEBRA678',
+      'location_type_id' => 'Home',
+      'contact_id' => $this->ids['contact'][0],
+      'country_id' => 'GB',
+    ]);
+    $address = $this->callAPISuccessGetSingle('Address', ['id' => $address['id']]);
+    // Check the postcode wasn't changed.
+    $this->assertEquals('ZEBRA678', $address['postal_code'] ?? NULL);
+    Address::delete(FALSE)->addWhere('id', '=', $address['id']);
+
+  }
   /**
    * Configure geocoders for testing.
    *


### PR DESCRIPTION
This adds support for a UK postcode geocoder. It does not add the data though as that's a 103MB sql file which exceeds GitHub's size allowance. The README has instructions for getting the data.

Of note:

- works on a db table
- allows missing/wrong spaces in postcodes, and corrects them
- I implemented a new provider since getting the existing db table one to play fair would have meant potentially breaking existing installs (assumptions over column names, numerical format of postal_code etc.)
- existing tests pass; new tests added for UK data.

