### PR TITLE
update Nominatim provider to use correct search URL

### DIFF
--- a/ProviderMetadata/1_OpenStreetMap.mgd.php
+++ b/ProviderMetadata/1_OpenStreetMap.mgd.php
@@ -16,7 +16,7 @@ return [
       'name' => 'open_street_maps',
       'title' => 'Nominatim (Open street maps)',
       'class' => 'Nominatim\Nominatim',
-      'url' => 'https://nominatim.openstreetmap.org/search',
+      'url' => 'https://nominatim.openstreetmap.org',
       'is_active' => FALSE,
       'weight' => 1,
     ],

--- a/api/v3/Geocoder/Geocode.php
+++ b/api/v3/Geocoder/Geocode.php
@@ -11,7 +11,7 @@ function civicrm_api3_geocoder_geocode($params) {
 
   // currently not working
   $httpClient = new \Http\Adapter\Guzzle6\Client();
-  $url = 'https://nominatim.openstreetmap.org/search';
+  $url = 'https://nominatim.openstreetmap.org';
   $provider = new Geocoder\Provider\Nominatim\Nominatim($httpClient, $url);
   $geocoder = new \Geocoder\StatefulGeocoder($provider, 'en');
   $result = $geocoder->geocodeQuery(GeocodeQuery::create('Disney Land, United States'));


### PR DESCRIPTION
Hi Eileen,

Nominatim have recently taken a stricter approach to the search URLs they process (see [Github issue](https://github.com/osm-search/Nominatim/issues/3134)). This leads to failures in this extension which reveal that the extension currently issues requests to URLs of the form https://nominatim.openstreetmap.org/search/search?format=jsonv2&q=[…] – note the duplicate “/search” in the path. This pull request repairs this problem, it has been tested on one affected instance. If you accept this and publish a new release soon it would be great, but maybe you would want to also include a cleaned up version of PR #36 which I will submit next.