### PR TITLE
[GEOCODER_45] : Pull request : composer, sql, openstreetmap_activation

### DIFF
--- a/CRM/Geocoder/Upgrader.php
+++ b/CRM/Geocoder/Upgrader.php
@@ -17,6 +17,101 @@ class CRM_Geocoder_Upgrader extends CRM_Extension_Upgrader_Base {
     $this->executeSqlFile('sql/install_zip_data_set.sql');
     civicrm_api3('Setting', 'create', ['geoProvider' => 'Geocoder']);
   }
+  
+  /**
+  * This function should be called by CRM_Extension_Upgrader_Base::onPostInstall
+  * in order to be able to work on managed entities
+  * only during install (and not during upgrade)
+  */
+  public function postInstall() {
+  $this->metadataEnableOnPostInstall();
+  
+  }
+  /**
+  * Some providers are not enabled through the managed entities,
+  * but uses metadata to require activation on install.
+  */
+  protected function metadataEnableOnPostInstall()
+  {
+    $geoCoders = [];
+    geocoder_civicrm_geo_managed($geoCoders); //defined in geocoder.php
+    /* we only need to enable geocoders that are not marked as active but that are enabled on install*/
+
+    $geoCodersToEnableOnPostInstall=array_filter($geoCoders,function($geocoder){
+      return
+      static::managedEntityHasName($geocoder)
+      && static::managedEntityIsEnabledOnInstall($geocoder)
+      && static::managedEntityIsNotActive($geocoder)
+      ;
+    
+    });
+
+    $geoCodersNames=array_map(function($geocoder){
+    return $geocoder['name'];
+    },$geoCodersToEnableOnPostInstall);
+    array_walk($geoCodersNames,function($geoCoderName){
+    static::activateGeocoder($geoCoderName);
+    });
+      
+  }
+  
+
+  /**
+  * Activate a geocoder by its name
+  * @param $geoCoderName string name of the GeoCoder to activate
+  * @return void
+  * @throws \CiviCRM_API3_Exception
+  */
+  protected static function activateGeocoder($geoCoderName)
+  {
+  /*api3 does error checking itself, so there is less need to do checking*/
+     $geoCoderId=civicrm_api3('Geocoder','getvalue',['return'=>"id",'name'=>$geoCoderName]);
+     civicrm_api3('Geocoder','create',['id'=>$geoCoderId,'is_active'=>1]);
+  }
+
+  /**
+  * Check whether a geocoder has a name
+  * according to a managed entity definition
+  * @param $geocoder array Array corresponding to a geocoder managed entity (as per geocoder_civicrm_geo_managed)
+  * @return bool
+  */
+  
+  protected static function managedEntityHasName($geocoder)
+  {
+    return
+      is_array($geocoder) && array_key_exists('name',$geocoder)
+      && is_string($geocoder['name']);
+  }
+  
+  /**
+  * Check whether a geocoder should be enabled on install or not,
+  * according to a managed entity definition
+  * @param $geocoder array Array corresponding to a geocoder managed entity (as per geocoder_civicrm_geo_managed)
+  * @return bool
+  */
+  protected static function managedEntityIsEnabledOnInstall($geocoder)
+  {
+     return
+      is_array($geocoder) && array_key_exists('metadata',$geocoder)
+      && is_array($geocoder['metadata']) && array_key_exists('is_enabled_on_install',$geocoder['metadata'])
+      && $geocoder['metadata']['is_enabled_on_install']===true;
+  }
+  
+  /**
+  * Check whether a geocoder should be active or not,
+  * according to a manged entity definition
+  * @param $geocoder array Array corresponding to a geocoder managed entity (as per geocoder_civicrm_geo_managed)
+  * @return bool : return true if the geocoder should not be active ; false otherwise
+  */
+  protected static function managedEntityIsNotActive($geocoder)
+  {
+     return
+     is_array($geocoder) && array_key_exists('params',$geocoder)
+     && is_array($geocoder['params']) && array_key_exists('is_active',$geocoder['params'])
+     && $geocoder['params']['is_active']===false;
+  }
+  
+  
 
   /**
    *  Add parameter column in DB

--- a/CRM/Utils/Geocode/Geocoder.php
+++ b/CRM/Utils/Geocode/Geocoder.php
@@ -28,8 +28,7 @@
 use Geocoder\Query\GeocodeQuery;
 use Geocoder\Model\AddressCollection;
 use CRM_Geocoder_ExtensionUtil as E;
-use Http\Adapter\Guzzle6\Client;
-
+use Http\Discovery\Psr18Client as Client;
 /**
  *
  * @package CRM
@@ -42,14 +41,14 @@ use Http\Adapter\Guzzle6\Client;
 class CRM_Utils_Geocode_Geocoder {
 
   /**
-   * @var \Http\Adapter\Guzzle6\Client
+   * @var \Http\Discovery\Psr18Client
    */
   protected static $client;
 
   /**
    * Get client.
    *
-   * @return \Http\Adapter\Guzzle6\Client
+   * @return Http\Discovery\Psr18Client
    */
   public static function getClient() {
     return self::$client;
@@ -58,7 +57,7 @@ class CRM_Utils_Geocode_Geocoder {
   /**
    * Set client.
    *
-   * @param \Http\Adapter\Guzzle6\Client $client
+   * @param Http\Discovery\Psr18Client
    */
   public static function setClient($client) {
     self::$client = $client;

--- a/api/v3/Geocoder/Geocode.php
+++ b/api/v3/Geocoder/Geocode.php
@@ -10,7 +10,7 @@ use Geocoder\Query\GeocodeQuery;
 function civicrm_api3_geocoder_geocode($params) {
 
   // currently not working
-  $httpClient = new \Http\Adapter\Guzzle6\Client();
+  $httpClient = new Http\Discovery\Psr18Client();
   $url = 'https://nominatim.openstreetmap.org';
   $provider = new Geocoder\Provider\Nominatim\Nominatim($httpClient, $url);
   $geocoder = new \Geocoder\StatefulGeocoder($provider, 'en');

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,9 @@
     }
   ],
   "require": {
-    "php-http/guzzle6-adapter": "2.*.*",
+    "php-http/discovery":"^1.17",
+    "psr/http-client-implementation":"*",
+    "psr/http-message-implementation":"*",
     "geocoder-php/free-geoip-provider": "^4.1",
     "php-http/message": "^1.6",
     "geocoder-php/nominatim-provider": "5.6.*",
@@ -26,18 +28,11 @@
     "wikimedia/civicrm-data-table-provider": "^5",
     "geo6/geocoder-php-addok-provider": "^1",
     "geocoder-php/here-provider": "^0.6",
-    "nyholm/psr7": "^1.8@dev",
     "geocoder-php/common-http": "4.5.*"
-  },
-  "replace": {
-    "guzzlehttp/guzzle": "^6.0",
-    "guzzlehttp/psr7": "^1.6.1",
-    "psr/http-message-implementation": "^1.0",
-    "psr/http-message": "^1.0.1"
   },
   "config": {
     "allow-plugins": {
-      "php-http/discovery": true
+      "php-http/discovery": false
     }
   }
 }

--- a/sql/install.sql
+++ b/sql/install.sql
@@ -12,7 +12,7 @@ CREATE TABLE `civicrm_geocoder` (
   `datafill_response_fields` varchar(255) COMMENT 'fields retained to fill but not overwrite data',
   `threshold_standdown` int DEFAULT 60 COMMENT 'Number of seconds to wait before retrying after hitting threshold. Geocaching delayed in this time',
   `threshold_last_hit` timestamp NULL COMMENT 'Timestamp when the threshold was last hit.',
-  `valid_countries` string NULL COMMENT 'Countries this geocoder is valid for',
+  `valid_countries` text NULL COMMENT 'Countries this geocoder is valid for',
   PRIMARY KEY (`id`)
 )
 ENGINE=InnoDB;

--- a/tests/phpunit/UpgraderTest.php
+++ b/tests/phpunit/UpgraderTest.php
@@ -1,0 +1,85 @@
+<?php
+
+class UpgraderTest extends \PHPUnit\Framework\TestCase
+{
+    public function managedEntityHasNameDataProvider()
+    {
+        return [
+            [null, false],
+            ["", false],
+            [["name" => "abc"], true]
+
+        ];
+
+    }
+
+    /**
+     * @dataProvider managedEntityHasNameDataProvider
+     * @param $entity
+     * @param $expected
+     * @return void
+     * @throws ReflectionException
+     */
+    public function testManagedEntityHasName($entity, $expected)
+    {
+        $method = new ReflectionMethod("CRM_Geocoder_Upgrader::managedEntityHasName");
+        $method->setAccessible(true);
+        $computed = $method->invoke(null, $entity);
+        $this->assertEquals($expected, $computed);
+    }
+
+    public function managedEntityIsEnabledOnInstallDataProvider()
+    {
+        return [
+            [null, false],
+            [[], false],
+            [["metadata" => null], false],
+            [["metadata" => []], false],
+            [["metadata" => ["is_enabled_on_install" => false]], false],
+            [["metadata" => ["is_enabled_on_install" => true]], true]
+        ];
+    }
+
+    /**
+     * @dataProvider managedEntityIsEnabledOnInstallDataProvider
+     * @param $entity
+     * @param $expected
+     * @return void
+     * @throws ReflectionException
+     */
+    public function testManagedEntityIsEnabledOnInstall($entity, $expected)
+    {
+        $method = new ReflectionMethod("CRM_Geocoder_Upgrader::managedEntityIsEnabledOnInstall");
+        $method->setAccessible(true);
+        $computed = $method->invoke(null, $entity);
+        $this->assertEquals($expected, $computed);
+    }
+
+    public function managedEntityIsNotActiveDataProvider()
+    {
+        return [
+            [null, false],
+            [[], false],
+            [["params" => null], false],
+            [["params" => []], false],
+            [["params" => ["is_active" => false]], true],
+            [["metadata" => ["is_active" => true]], false]
+        ];
+    }
+
+    /**
+     * @dataProvider managedEntityIsNotActiveDataProvider
+     * @param $entity
+     * @param $expected
+     * @return void
+     * @throws ReflectionException
+     */
+    public function testManagedEntityIsNotActive($entity,$expected)
+    {
+        $method = new ReflectionMethod("CRM_Geocoder_Upgrader::managedEntityIsNotActive");
+        $method->setAccessible(true);
+        $computed = $method->invoke(null, $entity);
+        $this->assertEquals($expected, $computed);
+    }
+
+}


### PR DESCRIPTION
This PR tries to bring some adjustements (at least, I hope so) : 
- sql : it seems that mysql does not recognize `string` type, so I changed it to `text`
- postInstall : needed to activate OpenStreetMap during a fresh install (see #45 )
- composer.json : while trying to install the extension altogether with drupal 9 and civicrm, I had to remove the replace section, because it did not install at all the required libraries mentionned in the `replace` section. Moreover, I tried to switch to Drupal 10, which leads to PHP 8.1 and guzzle v7, and requiring (indirectly) guzzle v6 make installation impossible. Using php-http/discovery without allowing plugin to run seems to provide a convenient way for solving this problem, as geocoder seems only need a PSR18 http client (running the plugin changes composer.json)
- I did not add the resulting vendor directory, as it should be produced by composer : however, this might be needed if someone install the extension directly and is relying on the included vendor directory (I guess it depends on the way an extension is packaged/released - I have no experience on that point)

I didn't manage to run the already included test suite ; however, I was able to run the unit test file (UpgraderTest.php) I added by specifying the test file on phpunit command line.

I did my best for this PR, but I'm still a novice in CiviCRM and in extensions, so please tell me if something is wrong or not appropriate.

Thanks !