### PR TITLE
GEOCODER_45 : Fix SQL install issue

### DIFF
--- a/sql/install.sql
+++ b/sql/install.sql
@@ -12,7 +12,7 @@ CREATE TABLE `civicrm_geocoder` (
   `datafill_response_fields` varchar(255) COMMENT 'fields retained to fill but not overwrite data',
   `threshold_standdown` int DEFAULT 60 COMMENT 'Number of seconds to wait before retrying after hitting threshold. Geocaching delayed in this time',
   `threshold_last_hit` timestamp NULL COMMENT 'Timestamp when the threshold was last hit.',
-  `valid_countries` string NULL COMMENT 'Countries this geocoder is valid for',
+  `valid_countries` text NULL COMMENT 'Countries this geocoder is valid for',
   PRIMARY KEY (`id`)
 )
 ENGINE=InnoDB;


### PR DESCRIPTION
It seems to me that `string` is not a valid mysql type (at least it didn't work for me).