### PR TITLE
GEOCODER_45 : composer adjustments

### DIFF
--- a/CRM/Utils/Geocode/Geocoder.php
+++ b/CRM/Utils/Geocode/Geocoder.php
@@ -28,8 +28,7 @@
 use Geocoder\Query\GeocodeQuery;
 use Geocoder\Model\AddressCollection;
 use CRM_Geocoder_ExtensionUtil as E;
-use Http\Adapter\Guzzle6\Client;
-
+use Http\Discovery\Psr18Client as Client;
 /**
  *
  * @package CRM
@@ -42,14 +41,14 @@ use Http\Adapter\Guzzle6\Client;
 class CRM_Utils_Geocode_Geocoder {
 
   /**
-   * @var \Http\Adapter\Guzzle6\Client
+   * @var \Http\Discovery\Psr18Client
    */
   protected static $client;
 
   /**
    * Get client.
    *
-   * @return \Http\Adapter\Guzzle6\Client
+   * @return Http\Discovery\Psr18Client
    */
   public static function getClient() {
     return self::$client;
@@ -58,7 +57,7 @@ class CRM_Utils_Geocode_Geocoder {
   /**
    * Set client.
    *
-   * @param \Http\Adapter\Guzzle6\Client $client
+   * @param Http\Discovery\Psr18Client
    */
   public static function setClient($client) {
     self::$client = $client;

--- a/api/v3/Geocoder/Geocode.php
+++ b/api/v3/Geocoder/Geocode.php
@@ -10,7 +10,7 @@ use Geocoder\Query\GeocodeQuery;
 function civicrm_api3_geocoder_geocode($params) {
 
   // currently not working
-  $httpClient = new \Http\Adapter\Guzzle6\Client();
+  $httpClient = new Http\Discovery\Psr18Client();
   $url = 'https://nominatim.openstreetmap.org';
   $provider = new Geocoder\Provider\Nominatim\Nominatim($httpClient, $url);
   $geocoder = new \Geocoder\StatefulGeocoder($provider, 'en');

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,9 @@
     "geocoder-php/here-provider": "^0.6",
     "geocoder-php/common-http": "4.5.*"
   },
+  "require-dev": {
+    "php-http/mock-client": "^1"
+  },
   "config": {
     "allow-plugins": {
       "php-http/discovery": false

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,9 @@
     }
   ],
   "require": {
-    "php-http/guzzle6-adapter": "2.*.*",
+    "php-http/discovery":"^1.17",
+    "psr/http-client-implementation":"*",
+    "psr/http-message-implementation":"*",
     "geocoder-php/free-geoip-provider": "^4.1",
     "php-http/message": "^1.6",
     "geocoder-php/nominatim-provider": "5.6.*",
@@ -26,18 +28,11 @@
     "wikimedia/civicrm-data-table-provider": "^5",
     "geo6/geocoder-php-addok-provider": "^1",
     "geocoder-php/here-provider": "^0.6",
-    "nyholm/psr7": "^1.8@dev",
     "geocoder-php/common-http": "4.5.*"
-  },
-  "replace": {
-    "guzzlehttp/guzzle": "^6.0",
-    "guzzlehttp/psr7": "^1.6.1",
-    "psr/http-message-implementation": "^1.0",
-    "psr/http-message": "^1.0.1"
   },
   "config": {
     "allow-plugins": {
-      "php-http/discovery": true
+      "php-http/discovery": false
     }
   }
 }


### PR DESCRIPTION
It seems to me that composer.json caused problems during a drupal/civicrm/geocoder install using composer. The replace section might not be appropriate as the extension itself does not implement the composer packages it claims to replace. 

Furthermore, replacing `\Http\Adapter\Guzzle6\Client` with `Http\Discovery\Psr18Client` might be more generic (I encountered composer install failures because of conflicting required versions of Guzzle). However, my experiments made me think that `php-http/discovery` plugin sometimes does changes to `composer.json`, so I think it might be better to disable the plugin.

This PR is an excerpt of PR #46 . As I wrote there ( <https://github.com/eileenmcnaughton/org.wikimedia.geocoder/pull/46#issue-1926121372>), I did not add the resulting vendor directory, as it should be produced by composer : however, this might be needed if someone install the extension directly and is relying on the included vendor directory (I guess it depends on the way an extension is packaged/released - I have no experience on that point).
