### PR TITLE
#54 fixes for Google Maps geocoding

### DIFF
--- a/CRM/Utils/Geocode/Geocoder.php
+++ b/CRM/Utils/Geocode/Geocoder.php
@@ -437,12 +437,7 @@ class CRM_Utils_Geocode_Geocoder {
    * @return string|array
    */
   protected static function getProviderArgument($geocoder) {
-    $argument = CRM_Utils_Array::value('argument', $geocoder);
-    if (is_string($argument) && substr($argument, 0, 9) === 'geocoder.') {
-      $split = explode('.', $argument);
-      return $geocoder[$split[1]];
-    }
-    return $argument;
+    return CRM_Utils_Array::value('argument', $geocoder);
   }
 
   /**
@@ -537,8 +532,12 @@ class CRM_Utils_Geocode_Geocoder {
     $arguments = (array) self::getProviderArgument($geocoder);
     $parameters = [];
     foreach ($arguments as $index => $argument) {
-       if (strpos($index, 'pass_through') === 0) {
+      if (strpos($index, 'pass_through') === 0) {
         $parameters[] = $argument;
+        continue;
+      }
+      if (is_null($argument)) {
+        $parameters[] = NULL;
         continue;
       }
       $parts = explode('.', $argument);

--- a/ProviderMetadata/4_GoogleMaps.mgd.php
+++ b/ProviderMetadata/4_GoogleMaps.mgd.php
@@ -22,7 +22,7 @@ return [
     'help_text' => ts('Adhering to Terms of service is your responsibility - https://support.google.com/code/answer/55180?hl=en'),
     'user_editable_fields' => ['api_key', 'threshold_standdown'],
     'metadata' => [
-      'argument' => 'geocoder.api_key',
+      'argument' => [NULL, 'geocoder.api_key'],
       'required_config_fields' => ['api_key'],
       // Not enabled by default, but special handling will enable if api key is already configured.
       'is_enabled_on_install' => FALSE,


### PR DESCRIPTION
New functionality in `getProviderClass()` to allow a `NULL` to be specified as a parameter, change Google metadata to pass `NULL` as first parameter when creating provider.

The change to `getProviderArgument()` is not required since this also changes the `argument` definition to an array instead of list, but seems sensible to fix this anyway.