### PR TITLE
Support geofilling county_id for google (and maybe other providers)

### DIFF
--- a/ProviderMetadata/1_OpenStreetMap.mgd.php
+++ b/ProviderMetadata/1_OpenStreetMap.mgd.php
@@ -16,6 +16,7 @@ return [
       'name' => 'open_street_maps',
       'title' => 'Nominatim (OpenStreetMap)',
       'class' => 'Nominatim\Nominatim',
+      'datafill_response_fields' => ["city", "state_province_id", "county_id"],
       'url' => 'https://nominatim.openstreetmap.org',
       'is_active' => FALSE,
       'weight' => 1,

--- a/ProviderMetadata/4_GoogleMaps.mgd.php
+++ b/ProviderMetadata/4_GoogleMaps.mgd.php
@@ -15,6 +15,7 @@ return [
       'name' => 'google_maps',
       'title' => 'Google Maps',
       'class' => 'GoogleMaps\GoogleMaps',
+      'datafill_response_fields' => ["city", "state_province_id", "county_id"],
       'api_key' =>  \Civi::settings()->get('geoAPIKey'),
       'is_active' => FALSE,
       'weight' => 5,


### PR DESCRIPTION
Update: Supports "County" field for Google + OSM.

![image](https://github.com/user-attachments/assets/82bcc0d9-af4e-4398-bfe8-47b67710ae92)

Google maps is working now and it does appear to include county if it's known, though it doesn't set it.

Generalized it so it stands a chance at working with other providers besides just Google Maps. Need county_id as a datafill for the provider.

@andyburnsco