### PR TITLE
Remove commented-out boilerplate

### DIFF
--- a/CRM/Geocoder/BAO/Geocoder.php
+++ b/CRM/Geocoder/BAO/Geocoder.php
@@ -3,25 +3,6 @@ use CRM_Geocoder_ExtensionUtil as E;
 
 class CRM_Geocoder_BAO_Geocoder extends CRM_Geocoder_DAO_Geocoder implements \Civi\Core\HookInterface {
 
-  /**
-   * Create a new Geocoder based on array-data
-   *
-   * @param array $params key-value pairs
-   * @return CRM_Geocoder_DAO_Geocoder|NULL
-   *
-  public static function create($params) {
-    $className = 'CRM_Geocoder_DAO_Geocoder';
-    $entityName = 'Geocoder';
-    $hook = empty($params['id']) ? 'create' : 'edit';
-
-    CRM_Utils_Hook::pre($hook, $entityName, $params['id'] ?? NULL, $params);
-    $instance = new $className();
-    $instance->copyValues($params);
-    $instance->save();
-    CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
-
-    return $instance;
-  } */
 
   /**
    * Event fired before an action is taken on an ACL record.


### PR DESCRIPTION
Civix used to generate commented-out BAO create functions, however all BAOs now inherit writeRecords() from their parent.

Since this function was never uncommented, it's safe to remove.