### PR TITLE
Fix address corruption bug by passing state/province correctly

### DIFF
--- a/CRM/Utils/Geocode/Geocoder.php
+++ b/CRM/Utils/Geocode/Geocoder.php
@@ -221,7 +221,7 @@ class CRM_Utils_Geocode_Geocoder {
     // filter out unrelated keys
     $keysToRetain = array_fill_keys($addressFields, 1);
     unset($keysToRetain['country_id'], $keysToRetain['state_province_id'], $keysToRetain['county_id']);
-    $keysToRetain['country'] = $keysToRetain['state_province_id'] = $keysToRetain['county'];
+    $keysToRetain['country'] = $keysToRetain['state_province'] = $keysToRetain['county'] = 1;
     $addressValues = array_intersect_key($addressValues, $keysToRetain);
 
     return $addressValues;
@@ -311,7 +311,7 @@ class CRM_Utils_Geocode_Geocoder {
     if (empty($geocoder['required_fields'])) {
       $keysToRetain = self::getAddressFields();
       unset($keysToRetain['country_id'], $keysToRetain['state_province_id'], $keysToRetain['county_id']);
-      $keysToRetain['country'] = $keysToRetain['state_province_id'] = $keysToRetain['county'] = 1;
+      $keysToRetain['country'] = $keysToRetain['state_province'] = $keysToRetain['county'] = 1;
       return array_keys($keysToRetain);
 
     }


### PR DESCRIPTION
I'm experiencing a corruption of addresses on CiviCRM 6.14 when using the geocoder extension with Nominatim.

Parsing and geocoding are enabled. When the first call of format() on the address was called and returned no results from OSM, the street address was popped off the address and format() was called again from civicrm-core/CRM/Utils/Address/BatchUpdate.php.

Due to a bug in getSendableFields() on line 314 of Geocoder.php, the state/province field gets removed from the address before the query is sent to OSM. OSM is queried using the county name and sorts the results by popularity. The county with the same name in a different state is the first result. The erroneous county and state were then written back to the DB replacing the correct county and state.

This fix keeps the state/province in the address used for the query. This returns the correct county and state result in OSM.